### PR TITLE
Fix soft delete filter

### DIFF
--- a/lib/cassandro/ext/soft_delete.rb
+++ b/lib/cassandro/ext/soft_delete.rb
@@ -1,7 +1,18 @@
 module Cassandro
   module SoftDelete
+    module ClassMethods
+      def all(with_deleted = false)
+        results = super()
+
+        results.reject!{ |r| r.deleted } unless with_deleted
+
+        results
+      end
+    end
+
     def self.included(model)
       model.attribute :deleted, :boolean
+      model.extend ClassMethods
     end
 
     def destroy

--- a/test/cassandro_migration_test.rb
+++ b/test/cassandro_migration_test.rb
@@ -6,6 +6,8 @@ Protest.describe "Cassandro Migration" do
   end
 
   test "enqueue migrations" do
+    Cassandro::Migration.clean
+
     class FirstMigration < Cassandro::Migration
       version 1
     end

--- a/test/cassandro_migrator_test.rb
+++ b/test/cassandro_migrator_test.rb
@@ -1,6 +1,7 @@
 require_relative 'helper'
 
 Protest.describe "Cassandro Migrator" do
+  Cassandro.connect(hosts: ['127.0.0.1'], keyspace: 'cassandro_test')
   setup do
     #Cassandro::Migration.cleaassandra::Errors::InvalidError
     Cassandro.client.execute("DROP TABLE IF EXISTS users")

--- a/test/cassandro_soft_delete_test.rb
+++ b/test/cassandro_soft_delete_test.rb
@@ -5,38 +5,38 @@ Protest.describe "Cassandro Model Soft Delete" do
   setup do
     Cassandro.connect(hosts: ['127.0.0.1'], keyspace: 'cassandro_test')
 
-    class User < Cassandro::Model
+    class Admin < Cassandro::Model
       include Cassandro::SoftDelete
 
-      table :users
+      table :admins
       attribute :nickname, :text
 
       primary_key :nickname
     end
 
 
-    User.all(true).each do |u|
-      Cassandro.execute("DELETE FROM users WHERE nickname = '#{u.nickname}'")
+    Admin.all(true).each do |a|
+      Cassandro.execute("DELETE FROM admins WHERE nickname = '#{a.nickname}'")
     end
   end
 
   test "all not include deleted" do
 
-    me = User.create(:nickname => "k4nd4lf")
-    other = User.create(:nickname => "Jim")
+    me = Admin.create(:nickname => "k4nd4lf")
+    other = Admin.create(:nickname => "Jim")
 
     me.destroy
 
-    assert !User.all.include?(me)
+    assert !Admin.all.include?(me)
   end
 
   test "all should include deleted if asked" do
-    me = User.create(:nickname => "k4nd4lf")
-    other = User.create(:nickname => "Jim")
+    me = Admin.create(:nickname => "k4nd4lf")
+    other = Admin.create(:nickname => "Jim")
 
     me.destroy
 
-    assert !User.all.include?(me)
+    assert !Admin.all.include?(me)
 
   end
 end

--- a/test/cassandro_soft_delete_test.rb
+++ b/test/cassandro_soft_delete_test.rb
@@ -1,0 +1,44 @@
+require_relative 'helper'
+require_relative 'support/tables'
+
+Protest.describe "Cassandro Model Soft Delete" do
+  setup do
+    Cassandro.connect(hosts: ['127.0.0.1'], keyspace: 'cassandro_test')
+
+    class User < Cassandro::Model
+      include Cassandro::SoftDelete
+
+      table :users
+      attribute :nickname, :text
+
+      primary_key :nickname
+    end
+
+
+    User.all(true).each do |u|
+      Cassandro.execute("DELETE FROM users WHERE nickname = '#{u.nickname}'")
+    end
+  end
+
+  test "all not include deleted" do
+
+    me = User.create(:nickname => "k4nd4lf")
+    other = User.create(:nickname => "Jim")
+
+    me.destroy
+
+    assert !User.all.include?(me)
+  end
+
+  test "all should include deleted if asked" do
+    me = User.create(:nickname => "k4nd4lf")
+    other = User.create(:nickname => "Jim")
+
+    me.destroy
+
+    assert !User.all.include?(me)
+
+  end
+end
+
+

--- a/test/support/tables.rb
+++ b/test/support/tables.rb
@@ -18,3 +18,13 @@ table = <<-TABLEDEF
   )
 TABLEDEF
 SESSION.execute(table)
+
+SESSION.execute("DROP TABLE IF EXISTS users")
+table = <<-TABLEDEF
+  CREATE TABLE IF NOT EXISTS users (
+    nickname VARCHAR,
+    deleted BOOLEAN,
+    PRIMARY KEY(nickname)
+  )
+TABLEDEF
+SESSION.execute(table)

--- a/test/support/tables.rb
+++ b/test/support/tables.rb
@@ -19,9 +19,9 @@ table = <<-TABLEDEF
 TABLEDEF
 SESSION.execute(table)
 
-SESSION.execute("DROP TABLE IF EXISTS users")
+SESSION.execute("DROP TABLE IF EXISTS admins")
 table = <<-TABLEDEF
-  CREATE TABLE IF NOT EXISTS users (
+  CREATE TABLE IF NOT EXISTS admins (
     nickname VARCHAR,
     deleted BOOLEAN,
     PRIMARY KEY(nickname)


### PR DESCRIPTION
This PR fixes `Cassandro::SoftDelete#all` method to not include the deleted records.
It redefines the `.all` method to be `.all(with_deleted = false)`, allowing to force the inclusion of the deleted records.
```
class Model < Cassandro::Model
  include SoftDelete
end

Model.all #=> will NOT include deleted instances
Model.all(true) #=> will include deleted instances
``` 
The PR also fixes `Cassandro::Migrator` tests by establishing the connection to cassandra before running the tests, and the `Cassandro::Migration` test by cleaning the queued migrations at the beginning of the test to remove the dependency with a previous migration 
