### PR TITLE
Allow nil native attributes on save

### DIFF
--- a/cassandro.gemspec
+++ b/cassandro.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency "cassandra-driver", '~> 1.2', '>= 1.0.0'
   s.add_development_dependency "protest", '~> 0.5', '>= 0.5.3'
+  s.add_development_dependency "rack-test", '~> 0.6', '>= 0.6.3'
 
   s.files = `git ls-files`.split("\n")
 end

--- a/lib/cassandro/model.rb
+++ b/lib/cassandro/model.rb
@@ -301,6 +301,12 @@ module Cassandro
       attrs ||= @attributes
 
       attrs.each do |k, v|
+        # bypassed nil values to avoid type casting errors
+        if attrs[k].nil?
+          n_attrs << nil
+          next
+        end
+
         case self.class.casts[k]
         when :uuid
           n_attrs << Cassandra::Uuid.new(attrs[k])

--- a/test/cassandro_model_test.rb
+++ b/test/cassandro_model_test.rb
@@ -81,6 +81,30 @@ Protest.describe "Cassandro Model" do
     end
   end
 
+  context 'Saving' do
+    setup do
+      class TestAttributes < Cassandro::Model
+        table 'tests_attributes'
+
+        attribute :test_col_1, :uuid
+        attribute :test_col_2, :text
+        attribute :test_col_3, :datetime
+
+        primary_key :test_col_1
+        unique :test_col_1
+      end
+
+      Cassandro.truncate_table('tests_attributes')
+    end
+
+    test "save a row with nil values" do
+      test = TestAttributes.create(test_col_1: SecureRandom.uuid, test_col_2: 'test_value_2', test_col_3: DateTime.now)
+      test.test_col_3 = nil
+      assert test.save
+      assert test.persisted?
+    end
+  end
+
   context 'Querying' do
     setup do
       class Test < Cassandro::Model

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,4 +21,4 @@ class Protest::TestCase
   include Rack::Test::Methods
 end
 
-Protest.report_with(:turn)
+ENV["PROTEST_REPORT"] ||= "turn"

--- a/test/support/tables.rb
+++ b/test/support/tables.rb
@@ -8,6 +8,17 @@ table = <<-TABLEDEF
 TABLEDEF
 SESSION.execute(table)
 
+SESSION.execute("DROP TABLE IF EXISTS tests_attributes")
+table = <<-TABLEDEF
+  CREATE TABLE IF NOT EXISTS tests_attributes (
+    test_col_1 UUID,
+    test_col_2 VARCHAR,
+    test_col_3 TIMESTAMP,
+    PRIMARY KEY(test_col_1)
+  )
+TABLEDEF
+SESSION.execute(table)
+
 SESSION.execute("DROP TABLE IF EXISTS patients")
 table = <<-TABLEDEF
   CREATE TABLE IF NOT EXISTS patients (


### PR DESCRIPTION
This PR fixes null values handle

```
⇒  PROTEST_REPORT=progress rake
....................

20 tests, 41 assertions (20 passed, 0 pending, 0 failed, 0 errored)
Ran in 3.55228 seconds
```