### PR TITLE
Adds Cassandro::Model#count class method

### DIFF
--- a/lib/cassandro/model.rb
+++ b/lib/cassandro/model.rb
@@ -236,6 +236,14 @@ module Cassandro
       Cassandro.client.execute(st, *values)
     end
 
+    def self.count
+      query = "SELECT count(*) FROM #{self.table_name}"
+
+      count = Cassandro.execute(query)
+
+      count.first["count"]
+    end
+
     protected
     def self.attributes
       @attributes ||= []

--- a/lib/cassandro/model.rb
+++ b/lib/cassandro/model.rb
@@ -210,12 +210,17 @@ module Cassandro
       results
     end
 
-    def self.count(key, value)
-      key = key.to_sym
-      query = "SELECT count(*) FROM #{table_name} WHERE #{key} = ? ALLOW FILTERING"
+    def self.count(key = nil, value = nil)
+      query = "SELECT count(*) FROM #{table_name}"
 
-      st = Cassandro.client.prepare(query)
-      results = Cassandro.client.execute(st, value)
+      if key && value
+        key = key.to_sym
+        query << " WHERE #{key} = ? ALLOW FILTERING"
+        st = Cassandro.client.prepare(query)
+        results = Cassandro.client.execute(st, value)
+      else
+        results = Cassandro.client.execute(query)
+      end
 
       results.first["count"]
     end
@@ -234,14 +239,6 @@ module Cassandro
       query = "SELECT * FROM #{table_name} WHERE #{where} ALLOW FILTERING"
       st = Cassandro.client.prepare(query)
       Cassandro.client.execute(st, *values)
-    end
-
-    def self.count
-      query = "SELECT count(*) FROM #{self.table_name}"
-
-      count = Cassandro.execute(query)
-
-      count.first["count"]
     end
 
     protected

--- a/test/cassandro_model_test.rb
+++ b/test/cassandro_model_test.rb
@@ -138,6 +138,13 @@ Protest.describe "Cassandro Model" do
       test = Test[{}]
       assert_equal nil, test
     end
+
+    test "counts the rows" do
+      Test.create(test_col_1: SecureRandom.uuid, test_col_2: 'test_value_2')
+      Test.create(test_col_1: SecureRandom.uuid, test_col_2: 'test_value_2')
+
+      assert_equal Test.all.size, Test.count
+    end
   end
 
   context 'Updating' do

--- a/test/cassandro_model_test.rb
+++ b/test/cassandro_model_test.rb
@@ -145,6 +145,14 @@ Protest.describe "Cassandro Model" do
 
       assert_equal Test.all.size, Test.count
     end
+
+    test "counts the rows with filter" do
+      uuid = SecureRandom.uuid
+      Test.create(test_col_1: uuid, test_col_2: 'test_value_2')
+      Test.create(test_col_1: SecureRandom.uuid, test_col_2: 'test_value_2')
+
+      assert_equal 1, Test.count(:test_col_1, Cassandra::Uuid.new(uuid))
+    end
   end
 
   context 'Updating' do


### PR DESCRIPTION
This PR adds `Cassandro::Model#count` method to avoid retrieving all the rows to count them.