### PR TITLE
Add TTL support to Cassandro::Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,31 @@ class  User < Cassandro::Model
 end
 ```
 
+Setting TTL to a model:
+
+```Ruby
+class Person < Cassandro::Model
+  table :people
+  ttl 60
+end
+```
+This will make all the instances of the People class will have a Time To Live of `60` seconds in the database.
+
+Creating a single record with a given TTL:
+
+```Ruby
+class Person < Cassandro::Model
+  table :people
+  attribute :first_name, :text
+  attribute :last_name, :text
+end
+
+Person.create_with_ttl(20, :first_name => "Eddie", :last_name => "Vedder")
+```
+
+This will create a record in the `people` table with a TTL of `20` seconds. It doesn't matter if the model has a different TTL set, this will override that TTL for _this record only_
+
+
 __A complete example__
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ class  User < Cassandro::Model
 end
 ```
 
-Setting TTL to a model:
+
+### Setting TTL to a model
 
 ```Ruby
 class Person < Cassandro::Model

--- a/cassandro.gemspec
+++ b/cassandro.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "cassandro"
-  s.version = "1.1.1"
+  s.version = "1.2.0"
   s.summary = "Ruby ORM for Apache Cassandra"
   s.license = "MIT"
   s.description = "Lightweight Apache Cassandra ORM for Ruby"


### PR DESCRIPTION
This PR adds support for creating records with a TTL using Cassandro::Model.

The TTL must be expressed in seconds and can be set for all the instances of a given class:

```Ruby
class Person < Cassandro::Model
  table :people
  ttl 60
end
```

Or can be used with the `Cassandro::Model#create_with_ttl` method:

```Ruby
class Person < Cassandro::Model
  table :people
  attribute :first_name, :text
  attribute :last_name, :text
end

Person.create_with_ttl(20, :first_name => "Eddie", :last_name => "Vedder")
```