### PR TITLE
Improve #find methods for SoftDelete extension

### DIFF
--- a/lib/cassandro/ext/soft_delete.rb
+++ b/lib/cassandro/ext/soft_delete.rb
@@ -8,6 +8,36 @@ module Cassandro
 
         results
       end
+
+      def where(key, value, with_deleted = false)
+        results = super(key, value)
+
+        results.reject!{ |r| r.deleted } unless with_deleted
+
+        results
+      end
+
+      def count(key = nil, value = nil, with_deleted = false)
+        return super(key, value) if with_deleted || key === true
+
+        if key && !value.nil?
+          results = where(key, value)
+        else
+          results = all
+        end
+
+        results.size
+      end
+
+      def query(where, *values)
+        with_deleted = where.scan(/\?/).length < values.length && values.pop === true
+
+        results = super(where, *values)
+
+        results.reject!{ |r| r.deleted } unless with_deleted
+
+        results
+      end
     end
 
     def self.included(model)

--- a/test/cassandro_soft_delete_test.rb
+++ b/test/cassandro_soft_delete_test.rb
@@ -21,7 +21,6 @@ Protest.describe "Cassandro Model Soft Delete" do
   end
 
   test "all not include deleted" do
-
     me = Admin.create(:nickname => "k4nd4lf")
     other = Admin.create(:nickname => "Jim")
 
@@ -38,6 +37,62 @@ Protest.describe "Cassandro Model Soft Delete" do
 
     assert !Admin.all.include?(me)
 
+  end
+
+  test "#where not includes deleted" do
+    me = Admin.create(:nickname => "tarolandia")
+    other = Admin.create(:nickname => "Jim")
+
+    me.destroy
+
+    assert_equal 0, Admin.where(:nickname, "tarolandia").size
+  end
+
+  test "#where should include deleted if asked" do
+    me = Admin.create(:nickname => "tarolandia")
+    other = Admin.create(:nickname => "Jim")
+
+    me.destroy
+
+    assert_equal 1, Admin.where(:nickname, "tarolandia", true).size
+  end
+
+  test "#count not includes deleted" do
+    me = Admin.create(:nickname => "tarolandia")
+    other = Admin.create(:nickname => "Jim")
+
+    me.destroy
+
+    assert_equal 1, Admin.count
+    assert_equal 0, Admin.count(:nickname, "tarolandia")
+  end
+
+  test "#count should include deleted if asked" do
+    me = Admin.create(:nickname => "tarolandia")
+    other = Admin.create(:nickname => "Jim")
+
+    me.destroy
+
+    assert_equal 2, Admin.count(true)
+    assert_equal 1, Admin.count(:nickname, "tarolandia", true)
+  end
+
+  test "#query not includes deleted" do
+    me = Admin.create(:nickname => "tarolandia")
+    other = Admin.create(:nickname => "Jim")
+
+    me.destroy
+
+    assert_equal 0, Admin.query("nickname = ?", "tarolandia").size
+  end
+
+  test "#query should include deleted if asked" do
+    me = Admin.create(:nickname => "tarolandia")
+    other = Admin.create(:nickname => "Jim")
+
+    me.destroy
+
+    assert_equal 1, Admin.query("nickname = ?", "tarolandia", true).size
   end
 end
 

--- a/test/cassandro_soft_delete_test.rb
+++ b/test/cassandro_soft_delete_test.rb
@@ -64,7 +64,6 @@ Protest.describe "Cassandro Model Soft Delete" do
     me.destroy
 
     assert_equal 1, Admin.count
-    assert_equal 0, Admin.count(:nickname, "tarolandia")
   end
 
   test "#count should include deleted if asked" do
@@ -74,6 +73,23 @@ Protest.describe "Cassandro Model Soft Delete" do
     me.destroy
 
     assert_equal 2, Admin.count(true)
+  end
+
+  test "#count should filter by key and exclude deleted" do
+    me = Admin.create(:nickname => "tarolandia")
+    other = Admin.create(:nickname => "Jim")
+
+    me.destroy
+
+    assert_equal 0, Admin.count(:nickname, "tarolandia")
+  end
+
+  test "#count should filter by key including deleted" do
+    me = Admin.create(:nickname => "tarolandia")
+    other = Admin.create(:nickname => "Jim")
+
+    me.destroy
+
     assert_equal 1, Admin.count(:nickname, "tarolandia", true)
   end
 


### PR DESCRIPTION
This PR redefines methods from Model for SoftDelete extension. `deleted` row are now not included by default in `query`, `count` and `where` methods.

Tests added.

refs #12 