### PR TITLE
Connection Check

### DIFF
--- a/cassandro.gemspec
+++ b/cassandro.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "cassandro"
-  s.version = "2.0.1"
+  s.version = "2.1.0"
   s.summary = "Ruby ORM for Apache Cassandra"
   s.license = "MIT"
   s.description = "Lightweight Apache Cassandra ORM for Ruby"

--- a/lib/cassandro/core.rb
+++ b/lib/cassandro/core.rb
@@ -32,7 +32,16 @@ module Cassandro
     @@session = nil
   end
 
+  def self.connected?
+    !@@session.nil?
+  end
+
+  def self.check_connection!
+    raise Cassandra::Errors::ClientError.new("Database connection is not stablished") unless connected?
+  end
+
   def self.execute(cql_command)
+    check_connection!
     @@session.execute(cql_command)
   end
 
@@ -51,11 +60,11 @@ module Cassandro
       #{with}
     KSDEF
 
-    @@session.execute(keyspace_definition)
+    execute(keyspace_definition)
   end
 
   def self.truncate_table(table_name)
-    @@session.execute("TRUNCATE #{table_name}")
+    execute("TRUNCATE #{table_name}")
   end
 
   def self.register_table(table_def)
@@ -63,10 +72,11 @@ module Cassandro
   end
 
   def self.load_tables
+    check_connection!
     @@tables.each do |table_definition|
       queries = table_definition.split(";").map(&:strip)
       queries.each do |query|
-        @@session.execute(query) unless query.empty?
+        execute(query) unless query.empty?
       end
     end
   end

--- a/lib/cassandro/core.rb
+++ b/lib/cassandro/core.rb
@@ -24,7 +24,7 @@ module Cassandro
   end
 
   def self.use(keyspace)
-    @@session.execute("USE #{keyspace}") if @@session
+    execute("USE #{keyspace}")
   end
 
   def self.disconnect

--- a/lib/cassandro/core.rb
+++ b/lib/cassandro/core.rb
@@ -40,9 +40,14 @@ module Cassandro
     raise Cassandra::Errors::ClientError.new("Database connection is not stablished") unless connected?
   end
 
-  def self.execute(cql_command)
+  def self.execute(statement, options = nil)
     check_connection!
-    @@session.execute(cql_command)
+    @@session.execute(statement, options)
+  end
+
+  def self.prepare(statement, options = nil)
+    check_connection!
+    @@session.prepare(statement, options)
   end
 
   def self.create_keyspace(name, options = { replication: { class: 'SimpleStrategy', replication_factor: 1}} )

--- a/lib/cassandro/ext/migration.rb
+++ b/lib/cassandro/ext/migration.rb
@@ -7,7 +7,7 @@ module Cassandro
     def down; end
 
     def execute(query)
-      Cassandro.client.execute(query)
+      Cassandro.execute(query)
     end
 
     def self.version(version_number)

--- a/lib/cassandro/ext/migrator.rb
+++ b/lib/cassandro/ext/migrator.rb
@@ -8,7 +8,7 @@ module Cassandro
       @migrations = Cassandro::Migration.migrations
       @logger = logger
 
-      Cassandro.client.execute CassandroMigration.schema
+      Cassandro.execute CassandroMigration.schema
 
       version = CassandroMigration[name: 'version'] || CassandroMigration.create(name: 'version', value: "0")
 

--- a/lib/cassandro/model.rb
+++ b/lib/cassandro/model.rb
@@ -49,6 +49,8 @@ module Cassandro
     end
 
     def update_attributes(attrs = {})
+      Cassandro.check_connection!
+
       attrs = attrs.inject({}) do |memo, (k,v)|
         memo[k.to_sym] = (v.nil? || v.to_s.empty?) ? nil : v #TODO: fix for Set, Map
         memo
@@ -80,6 +82,8 @@ module Cassandro
     end
 
     def save(insert_check = false)
+      Cassandro.check_connection!
+
       clear_errors
 
       if self.class.casts[:id] == :uuid
@@ -171,6 +175,8 @@ module Cassandro
     end
 
     def self.[](value)
+      Cassandro.check_connection!
+
       return nil if value.nil? || (value.respond_to?(:empty?) && value.empty?)
 
       if value.is_a?(Hash)
@@ -224,6 +230,8 @@ module Cassandro
     end
 
     def self.where(key, value)
+      Cassandro.check_connection!
+
       key = key.to_sym
       results = []
 
@@ -240,6 +248,8 @@ module Cassandro
     end
 
     def self.count(key = nil, value = nil)
+      Cassandro.check_connection!
+
       query = "SELECT count(*) FROM #{table_name}"
 
       if key && !value.nil?
@@ -265,6 +275,8 @@ module Cassandro
     end
 
     def self.query(where, *values)
+      Cassandro.check_connection!
+
       results = []
 
       query = "SELECT * FROM #{table_name} WHERE #{where} ALLOW FILTERING"

--- a/lib/cassandro/model.rb
+++ b/lib/cassandro/model.rb
@@ -73,7 +73,8 @@ module Cassandro
         Cassandro.execute(st, arguments: native_attributes(attrs))
         @attributes.merge!(attrs)
         true
-      rescue Exception => e
+      rescue => e
+        raise unless Cassandro.connected?
         @errors[:update_error] = e.message
         false
       end
@@ -105,6 +106,7 @@ module Cassandro
         raise ModelException.new('not_applied') unless !insert_check || (insert_check && r.first["[applied]"])
         @persisted = true
       rescue => e
+        raise unless Cassandro.connected?
         @attributes[:id] = nil if !persisted? && @attributes.has_key?(:id)
         @errors[:save] = e.message
         false
@@ -259,7 +261,8 @@ module Cassandro
         query = "TRUNCATE #{table_name}"
         st = Cassandro.execute(query)
         st.is_a? Cassandra::Client::VoidResult
-      rescue e
+      rescue => e
+        raise unless Cassandro.connected?
         false
       end
     end

--- a/test/cassandro_check_connection_test.rb
+++ b/test/cassandro_check_connection_test.rb
@@ -1,0 +1,123 @@
+require_relative 'helper'
+
+Protest.describe "Cassandro Connection check" do
+  setup do
+    class Admin < Cassandro::Model
+      table :admins
+      attribute :nickname, :text
+      attribute :age, :integer
+
+      primary_key :nickname
+    end
+
+    Cassandro.disconnect
+  end
+
+  context "Core" do
+    test "raise Exception on #execute" do
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        Cassandro.execute("USE test_keyspace")
+      end
+    end
+
+    test "raise Exception on #use" do
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        Cassandro.use("test_keyspace")
+      end
+    end
+
+    test "raise Exception on #create_keyspace" do
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        Cassandro.create_keyspace("test_keyspace")
+      end
+    end
+
+    test "raise Exception on #truncate_table" do
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        Cassandro.truncate_table("tests")
+      end
+    end
+  end
+
+  context "Model" do
+    test "raise Exception on #create" do
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        Admin.create(nickname: "tarolandia")
+      end
+    end
+
+    test "raise Exception on #save" do
+      admin = Admin.new(nickname: "tarolandia")
+
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        admin.save
+      end
+    end
+
+    test "raise Exception on #update_attributes" do
+      admin = Admin.new(nickname: "tarolandia")
+
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        admin.update_attributes(age: 29)
+      end
+    end
+
+    test "raise Exception on #[]" do
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        Admin[nickname: "tarolandia"]
+      end
+    end
+
+    test "raise Exception on #all" do
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        Admin.all
+      end
+    end
+
+    test "raise Exception on #where" do
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        Admin.where(:nickname, "tarolandia")
+      end
+    end
+
+    test "raise Exception on #count" do
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        Admin.count
+      end
+    end
+
+    test "raise Exception on #query" do
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        Admin.query("nickname = ?", "tarolandia")
+      end
+    end
+
+    test "raise Exception on #ttl" do
+      admin = Admin.new(nickname: "tarolandia")
+
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        admin.ttl
+      end
+    end
+
+    test "raise Exception on #create_with_ttl" do
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        Admin.create_with_ttl(20, nickname: "tarolandia", age: 29)
+      end
+    end
+
+    test "raise Exception on #destroy" do
+      admin = Admin.new(nickname: "tarolandia")
+
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        admin.destroy
+      end
+    end
+
+    test "raise Exception on #destroy_all" do
+      assert_raise(Cassandra::Errors::ClientError, "Database connection is not stablished") do
+        Admin.destroy_all
+      end
+    end
+  end
+end

--- a/test/cassandro_migrator_test.rb
+++ b/test/cassandro_migrator_test.rb
@@ -1,12 +1,12 @@
 require_relative 'helper'
 
 Protest.describe "Cassandro Migrator" do
-  Cassandro.connect(hosts: ['127.0.0.1'], keyspace: 'cassandro_test')
   setup do
-    #Cassandro::Migration.cleaassandra::Errors::InvalidError
-    Cassandro.client.execute("DROP TABLE IF EXISTS users")
-    Cassandro.client.execute("DROP TABLE IF EXISTS animals")
-    Cassandro.client.execute("DROP TABLE IF EXISTS cassandro_migrations")
+    Cassandro.connect(hosts: ['127.0.0.1'], keyspace: 'cassandro_test')
+
+    Cassandro.execute("DROP TABLE IF EXISTS users")
+    Cassandro.execute("DROP TABLE IF EXISTS animals")
+    Cassandro.execute("DROP TABLE IF EXISTS cassandro_migrations")
     @migrator = Cassandro::Migrator.new("./test/support/migrations", Logger.new('/dev/null'))
   end
 

--- a/test/cassandro_test.rb
+++ b/test/cassandro_test.rb
@@ -3,6 +3,7 @@ require_relative 'helper'
 Protest.describe "Cassandro Module" do
   setup do
     SESSION.execute("DROP KEYSPACE IF EXISTS test_keyspace")
+    Cassandro.disconnect
   end
 
   test "connects to database" do
@@ -14,6 +15,12 @@ Protest.describe "Cassandro Module" do
     Cassandro.connect(hosts: ["127.0.0.1"])
     assert_equal Cassandra::Results::Void, Cassandro.create_keyspace("test_keyspace").class
     assert_equal Cassandra::Results::Void, Cassandro.use("test_keyspace").class
+  end
+
+  test "raise error if not connected" do
+    assert_raise(Cassandra::Errors::ClientError) do
+      Cassandro.execute("USE test_keyspace")
+    end
   end
 end
 

--- a/test/cassandro_test.rb
+++ b/test/cassandro_test.rb
@@ -16,11 +16,4 @@ Protest.describe "Cassandro Module" do
     assert_equal Cassandra::Results::Void, Cassandro.create_keyspace("test_keyspace").class
     assert_equal Cassandra::Results::Void, Cassandro.use("test_keyspace").class
   end
-
-  test "raise error if not connected" do
-    assert_raise(Cassandra::Errors::ClientError) do
-      Cassandro.execute("USE test_keyspace")
-    end
-  end
 end
-


### PR DESCRIPTION
This PR implements a connection check for Cassandro.
If connection was not established to database, Cassandro will raise a `Cassandra::Errors::ClientError` exception with message `Database connection is not stablished`

I added a new tests file covering all methods using connection to database.
